### PR TITLE
Fixed typo in the addon's Settings page

### DIFF
--- a/src/options/components/mode-radio-group.tsx
+++ b/src/options/components/mode-radio-group.tsx
@@ -8,12 +8,12 @@ const options = [
   {
     id: Mode.Active,
     name: "Active",
-    description: "Enable Recap by default, disable particular domains mamually"
+    description: "Enable Recap by default, disable particular domains manually"
   },
   {
     id: Mode.Passive,
     name: "Passive",
-    description: "Disable Recap by default, enable particular domains mamually"
+    description: "Disable Recap by default, enable particular domains manually"
   }
 ]
 


### PR DESCRIPTION
Just a tiny fix for this typo.

![image](https://user-images.githubusercontent.com/5185770/236851921-22fea326-6cd7-4669-b886-6ebc65e44a28.png)
